### PR TITLE
Tim/specify dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ It's basically a Streamlit wrapper over [echarts-for-react](https://github.com/h
 ## Install
 
 ```shell script
-pip install pyecharts simplejson  # <-- optional, if you need to use st_pyecharts
-pip install -i https://test.pypi.org/simple/ --no-deps streamlit-echarts
+pip install -i https://test.pypi.org/simple/ streamlit-echarts
 ```
 
 ## Run

--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,9 @@ setuptools.setup(
     include_package_data=True,
     classifiers=[],
     python_requires=">=3.6",
+    install_requires=[
+        "streamlit >= 0.63",
+        "simplejson >= 3.0",
+        "pyecharts >= 1.8",
+    ]
 )


### PR DESCRIPTION
Hey @andfanilo! This changes `setup.py` to list the dependencies that the component requires. 

(We neglected to add this to the template (but I'm fixing that now)).

I also changed the README to remove the `pip install pyecharts simplejson` installation step; these will now be installed automatically.

(If you want `simplejson` to be optional, you'll need to check that it's available before importing and using it in `__init__.py`, or else you'll get a runtime exception.)

I set the Streamlit requirement to "streamlit >= 0.63", which does not yet exist, but my _assumption_ is that this is the release we'll release custom components into open beta. I'll circle back on this before we actually launch.