### PR TITLE
  readd support for event back to python after useEffect commit

### DIFF
--- a/streamlit_echarts/frontend/src/EchartsChart.tsx
+++ b/streamlit_echarts/frontend/src/EchartsChart.tsx
@@ -80,6 +80,30 @@ const EchartsChart = (props: ComponentProps) => {
 
   const cleanOptions = convertJavascriptCode(options)
   const cleanOnEvents = convertJavascriptCode(onEvents)
+  /*
+  add support for event back to python
+  usage at python side:
+  ```
+  events={
+    "click": "function(params) { alert(params.name);return params.name }",
+    "dblclick":"function(params) { return params.value }"
+  }
+  s=st_pyecharts(b,events=events)
+  ```
+  or, 
+  ```
+  events={
+    "click": "function(params) { return [params.type,params.name,params.value] }"    
+  }
+  s=st_pyecharts(b,events=events)
+   */
+  const getReturnOfcleanOnEvents: any = {}
+  const keys = Object.keys(cleanOnEvents).forEach(function (key) {
+    getReturnOfcleanOnEvents[key] = (params: any) => {
+      const s = cleanOnEvents[key](params)
+      Streamlit.setComponentValue(s)
+    }
+  })
 
   useEffect(() => {
     if (null === echartsElementRef.current) {
@@ -101,7 +125,7 @@ const EchartsChart = (props: ComponentProps) => {
         onChartReady={() => {
           Streamlit.setFrameHeight()
         }}
-        onEvents={cleanOnEvents}
+        onEvents={getReturnOfcleanOnEvents}
         opts={{ renderer: renderer }}
       />
     </>


### PR DESCRIPTION
hi, 
sorry a little late, fix git problems with version confict...
I add codes after your version.
and I found that ,we can get multi parameter value back using [] , which may support various end-user need.
please take a look,
thanks!

add support for event back to python
  usage at python side:
  ```
  events={
    "click": "function(params) { alert(params.name);return params.name }",
    "dblclick":"function(params) { return params.value }"
  }
  s=st_pyecharts(b,events=events)
  ```
  or, 
  ```
  events={
    "click": "function(params) { return [params.name,params.value] }"    
  }
  s=st_pyecharts(b,events=events)
```
